### PR TITLE
Add support for Qt6

### DIFF
--- a/SoAny.cpp.in
+++ b/SoAny.cpp.in
@@ -433,7 +433,7 @@ SoAny::getenv(const char * envname)
      toolkits).  If you do bug fixes or whatever, keep them in sync! */
 #ifdef HAVE_GETENVIRONMENTVARIABLE
   int neededsize;
-  neededsize = GetEnvironmentVariable(envname, NULL, 0);
+  neededsize = GetEnvironmentVariableA(envname, NULL, 0);
   /* neededsize includes the \0-terminating character */
   if ( neededsize >= 1 ) {
     int resultsize;
@@ -445,7 +445,7 @@ SoAny::getenv(const char * envname)
          to reuse it (much work for a non-100% solution).  20030205 larsa */
       return NULL;
     }
-    resultsize = GetEnvironmentVariable(envname, valbuf, neededsize);
+    resultsize = GetEnvironmentVariableA(envname, valbuf, neededsize);
     if ( resultsize != (neededsize - 1) ) {
       /* Augh. Could we handle this any better? */
       /* How about looping to top and trying again (in case the reason is mt
@@ -528,8 +528,8 @@ SoAny::listWin32ProcessModules(void)
 {
   BOOL ok;
 
-  HINSTANCE kernel32dll = LoadLibrary("kernel32.dll");
-  assert(kernel32dll && "LoadLibrary(''kernel32.dll'') failed");
+  HINSTANCE kernel32dll = LoadLibraryA("kernel32.dll");
+  assert(kernel32dll && "LoadLibraryA(''kernel32.dll'') failed");
 
   funCreateToolhelp32Snapshot = (CreateToolhelp32Snapshot_t)
     GetProcAddress(kernel32dll, "CreateToolhelp32Snapshot");

--- a/SoGuiRenderArea.cpp.in
+++ b/SoGuiRenderArea.cpp.in
@@ -162,7 +162,6 @@
 #endif // HAVE_CONFIG_H
 
 #if SOQT_DEBUG // For the "soinfo" debugging backdoor.
-#include <qgl.h>
 #include <qapplication.h>
 #endif // SOQT_DEBUG
 


### PR DESCRIPTION
The header `qgl.h` is no longer valid on Qt6 and was apparently also not required on Qt4 and Qt5 in this file.

`GetEnvironmentVariable` and `LoadLibrary` need to be replaced with `GetEnvironmentVariableA` and `LoadLibraryA`, otherwise `GetEnvironmentVariableW` and `LoadLibraryW` are called, which expect `LPCWSTR`:
```
  SoAny.cpp
src\Inventor\Qt\SoAny.cpp(436,55): error C2664: 'DWORD GetEnvironmentVariableW(LPCWSTR,LPWSTR,DWORD)': cannot convert argument 1 from 'const char *' to 'LPCWSTR' [src\SoQt.vcxproj]
src\Inventor\Qt\SoAny.cpp(436,39): message : Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast [C:\Users\Mar
kus\tmp\soqt-build\src\SoQt.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um\processenv.h(161,1): message : see declaration of 'GetEnvironmentVariableW' [src\SoQt.vcxproj]
src\Inventor\Qt\SoAny.cpp(448,68): error C2664: 'DWORD GetEnvironmentVariableW(LPCWSTR,LPWSTR,DWORD)': cannot convert argument 1 from 'const char *' to 'LPCWSTR' [src\SoQt.vcxproj]
src\Inventor\Qt\SoAny.cpp(448,41): message : Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast [C:\Users\Mar
kus\tmp\soqt-build\src\SoQt.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um\processenv.h(161,1): message : see declaration of 'GetEnvironmentVariableW' [src\SoQt.vcxproj]
src\Inventor\Qt\SoAny.cpp(531,53): error C2664: 'HMODULE LoadLibraryW(LPCWSTR)': cannot convert argument 1 from 'const char [13]' to 'LPCWSTR' [C:\Users\Markus\tmp\
soqt-build\src\SoQt.vcxproj]
src\Inventor\Qt\SoAny.cpp(531,39): message : Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast [C:\Users\Mar
kus\tmp\soqt-build\src\SoQt.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um\libloaderapi.h(671,1): message : see declaration of 'LoadLibraryW' [src\SoQt.vcxproj]
```