### PR TITLE
Replace non-ASCII characters

### DIFF
--- a/SoGuiRenderArea.cpp.in
+++ b/SoGuiRenderArea.cpp.in
@@ -1845,7 +1845,7 @@ So@Gui@RenderArea::redraw(void)
     So@Gui@ExaminerViewer::actualRedraw();
   
   
-    // Increase arrow angle with 1/1000 ° every frame.
+    // Increase arrow angle with 1/1000 degrees every frame.
     arrowrotation->angle = arrowrotation->angle.getValue() + (0.001 / M_PI * 180);
     // Render overlay front scene graph.
     glClear(GL_DEPTH_BUFFER_BIT);

--- a/viewers/SoGuiExaminerViewer.cpp.in
+++ b/viewers/SoGuiExaminerViewer.cpp.in
@@ -983,7 +983,7 @@ SoGuiExaminerViewerP::drawAxisCross(void)
 
   const float NEARVAL = 0.1f;
   const float FARVAL = 10.0f;
-  const float dim = NEARVAL * float(tan(M_PI / 8.0)); // FOV is 45° (45/360 = 1/8)
+  const float dim = NEARVAL * float(tan(M_PI / 8.0)); // FOV is 45 degrees (45/360 = 1/8)
   glFrustum(-dim, dim, -dim, dim, NEARVAL, FARVAL);
 
 

--- a/viewers/SoGuiFullViewer.h.in
+++ b/viewers/SoGuiFullViewer.h.in
@@ -150,7 +150,7 @@ protected:
 private:
   // Private class for implementation hiding. The idiom we're using is
   // a variant of what is known as the "Cheshire Cat", and is also
-  // described as the "Bridge" pattern in «Design Patterns» by Gamma
+  // described as the "Bridge" pattern in <<Design Patterns>> by Gamma
   // et al (aka The Gang Of Four).
   class So@Gui@FullViewerP * pimpl;
 

--- a/viewers/SoGuiViewer.cpp.in
+++ b/viewers/SoGuiViewer.cpp.in
@@ -420,7 +420,7 @@ So@Gui@ViewerP::getCameraCoordinateSystem(SoCamera * cameraarg,
 // These functions do this:
 //
 //       * when going from orthocam -> perspectivecam: set the
-//       heightAngle field to its default value (45°), and move
+//       heightAngle field to its default value (45 degrees), and move
 //       camera to a position where the scene/model would fill about
 //       the same screenspace as it did in the orthocam
 //
@@ -451,7 +451,7 @@ So@Gui@ViewerP::convertOrtho2Perspective(const SoOrthographicCamera * in,
 
   out->focalDistance.setValue(focaldist);
   
-  // 45° is the default value of this field in SoPerspectiveCamera.
+  // 45 degrees is the default value of this field in SoPerspectiveCamera.
     out->heightAngle = (float)(M_PI / 4.0);
 
 #if SO@GUI@_DEBUG && 0 // debug


### PR DESCRIPTION
This PR replaces non-ASCII characters to remove compiler warnings (C4828) when building files via MSVC:
```
src\Inventor\Qt\SoQtRenderArea.cpp(1833): warning C4828: The file contains a character starting at offset 0xe1ee that is illegal in the current source character set (codepage 65001).
src\Inventor\Qt\viewers\SoQtExaminerViewer.cpp(856): warning C4828: The file contains a character starting at offset 0x7f6e that is illegal in the current source character set (codepage 65001).
src\Inventor/Qt/viewers/SoQtFullViewer.h(1): warning C4828: The file contains a character starting at offset 0x1561 that is illegal in the current source character set (codepage 65001).
src\Inventor\Qt\viewers\SoQtViewer.cpp(1): warning C4828: The file contains a character starting at offset 0x3d68 that is illegal in the current source character set (codepage 65001).
```