### PR TITLE
Added missing dll export on Windows. avoid a core dump on linux in MaterialEditor

### DIFF
--- a/editors/SoGuiColorEditor.h.in
+++ b/editors/SoGuiColorEditor.h.in
@@ -45,7 +45,7 @@ class SoSFColor;
 class SoMFColor;
 class SoMFUInt32;
 
-class So@Gui@ColorEditor : public So@Gui@RenderArea {
+class SO@GUI@_DLL_API So@Gui@ColorEditor : public So@Gui@RenderArea {
   SO@GUI@_OBJECT_HEADER(So@Gui@ColorEditor, So@Gui@RenderArea);
 
 public:

--- a/nodes/SceneTexture2.cpp.in
+++ b/nodes/SceneTexture2.cpp.in
@@ -187,7 +187,12 @@ SceneTexture2::render_cb(void * closure, SoSensor * sensor)
     me->renderer->render(scene);
     unsigned char * renderbuffer = me->renderer->getBuffer();
     unsigned char * imagebytes = PUBLIC(me)->image.startEditing(size, nc);
-    memcpy(imagebytes, renderbuffer, size[0] * size[1] * nc);
+    if(renderbuffer != 0) {
+      memcpy(imagebytes, renderbuffer, size[0] * size[1] * nc);
+    } else {
+      SoDebugError::postWarning("SceneTexture2::render_cb",
+                                "render buffer is null");
+    }
     PUBLIC(me)->image.finishEditing();
   } else {
     unsigned char * imagebytes = PUBLIC(me)->image.startEditing(size, nc);


### PR DESCRIPTION
Hello,
So@Gui@MaterialEditor presents a problem with offscreen renderer in linux (the same problem in Centos 7 and Ubuntu 24).
This correction avoid the crash, but the image with the preview color is missing.
I will investigate on Coin for solving the problem definitely.

Cheers

   Fabrizio

